### PR TITLE
Widmann/feat dynamic update

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
 		"rtn-msg-interval": "90",
 		"rtn-msg-interval-jitter": "1",
 		"rtn-msg-interval-dynamic": false,
+		"dynamic-update-enabled": true,
 
 		"mcast-v4-tx-addr": "224.0.1.241",
 		"mcast-v6-tx-addr": "ff05:0:0:0:0:0:0:2",

--- a/config.json
+++ b/config.json
@@ -1,22 +1,36 @@
 {
 	"core" : {
+		"id": "test-id",
 		"rtn-msg-hold-time": "90",
-		"rtn-msg-interval": "30",
+		"rtn-msg-interval": "10",
 		"rtn-msg-interval-jitter": "7",
 
-		"mcast-v4-tx-addr": "224.0.0.1",
+		"mcast-v4-tx-addr": "224.0.1.241",
 		"mcast-v6-tx-addr": "ff05:0:0:0:0:0:0:2",
 
 		"interfaces": [
 			{
-				"name": "eth0",
+				"name": "eno1",
 				"port" : 33751,
 				"type": "mcast",
 				"addr-v4": "10.10.10.228",
 				"ttl-v4": "8",
 				"addr-v6": "f9c8:e83:c795:dd93:114:e409:885c:7520",
 				"ttl-v6": "8",
-				"link-characteristics": {
+				"link-attributes": {
+					"bandwidth": 5000,
+					"loss": 4
+				}
+			},
+			{
+				"name": "eno1",
+				"port" : 33751,
+				"type": "mcast",
+				"addr-v4": "10.10.10.228",
+				"ttl-v4": "8",
+				"addr-v6": "f9c8:e83:c795:dd93:114:e409:885c:7520",
+				"ttl-v6": "8",
+				"link-attributes": {
 					"bandwidth": 5000,
 					"loss": 4
 				}

--- a/config.json
+++ b/config.json
@@ -1,27 +1,15 @@
 {
 	"core" : {
 		"id": "test-id",
-		"rtn-msg-hold-time": "90",
-		"rtn-msg-interval": "10",
-		"rtn-msg-interval-jitter": "7",
+		"rtn-msg-hold-time": "360",
+		"rtn-msg-interval": "90",
+		"rtn-msg-interval-jitter": "1",
+		"rtn-msg-interval-dynamic": false,
 
 		"mcast-v4-tx-addr": "224.0.1.241",
 		"mcast-v6-tx-addr": "ff05:0:0:0:0:0:0:2",
 
 		"interfaces": [
-			{
-				"name": "eno1",
-				"port" : 33751,
-				"type": "mcast",
-				"addr-v4": "10.10.10.228",
-				"ttl-v4": "8",
-				"addr-v6": "f9c8:e83:c795:dd93:114:e409:885c:7520",
-				"ttl-v6": "8",
-				"link-attributes": {
-					"bandwidth": 5000,
-					"loss": 4
-				}
-			},
 			{
 				"name": "eno1",
 				"port" : 33751,
@@ -40,11 +28,6 @@
 		"networks": [
 			{
 				"prefix": "44.101.177.0",
-				"prefix-len": 24,
-				"proto": "v4"
-			},
-			{
-				"prefix": "155.183.88.0",
 				"prefix-len": 24,
 				"proto": "v4"
 			}

--- a/dmprd.py
+++ b/dmprd.py
@@ -227,7 +227,6 @@ class DMPRD(object):
                 'receive packet: {}:{} [{}]'.format(src_addr, src_port,
                                                     iface_name))
         except socket.error as e:
-            print("\n\n\n\n sock error")
             logger.exception('error while receiving packet', exc_info=e)
             return
 

--- a/dmprd.py
+++ b/dmprd.py
@@ -63,9 +63,7 @@ class MulticastTxSocket(socket.socket):
             # bind the socket to the right interface
             # no idea why its 25, just found it somewhere in the internet and it works
             self.setsockopt(socket.SOL_SOCKET, 25, interface_name.encode('utf-8'))
-
             mreq = struct.pack("=4sl", socket.inet_aton(multicast_address), socket.INADDR_ANY)
-
             self.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, mreq)
             # Set the TTL
             self.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl_bin)
@@ -113,7 +111,6 @@ class MulticastRxSocket(socket.socket):
 
             # Allow looping if MCAST_LOOP is set to 1
             self.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 0)
-            self.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 8)
             self.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, ip_mreqn)
 
         elif addrinfo[0] == socket.AF_INET6:

--- a/dmprd.py
+++ b/dmprd.py
@@ -116,8 +116,6 @@ class MulticastRxSocket(socket.socket):
             self.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 8)
             self.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, ip_mreqn)
 
-
-
         elif addrinfo[0] == socket.AF_INET6:
             # See https://github.com/torvalds/linux/blob/866ba84ea30f94838251f74becf3cfe3c2d5c0f9/include/uapi/linux/in6.h#L60
             # struct defines the multicast address and interface index
@@ -183,6 +181,9 @@ class DMPRD(object):
         self.core.register_policy(core.dmpr.SimpleBandwidthPolicy())
 
         self.core.start()
+
+    def handle_dynamic_update(self, jsonData):
+        self.core.handle_dynamic_update(jsonData)
 
     def start(self):
         asyncio.ensure_future(self.ticker())
@@ -440,11 +441,12 @@ def main():
     event_loop = asyncio.get_event_loop()
     event_loop.set_debug(True)
 
+    dmprd = DMPRD(conf, event_loop)
+
     if 'httpd' in conf:
         logger.info("Start HTTPD")
         http_server = httpd.httpd.Httpd()
-
-    dmprd = DMPRD(conf, event_loop)
+        http_server.register_api_callback(dmprd.handle_dynamic_update)
 
     # if 'route-info-broadcaster' in conf:
     #    asyncio.ensure_future(route_broadcast({}))

--- a/dmprd.py
+++ b/dmprd.py
@@ -240,7 +240,9 @@ class DMPRD(object):
 
     def cb_routing_table_update(self, routing_tables):
         self.routing_table = routing_tables
-        # broadcast_routing_table(ctx)
+        ctx = {'conf': self.conf,
+               'routing-tables': self.routing_table}
+        broadcast_routing_table(ctx)
 
     #########
     # utils #

--- a/httpd/httpd.py
+++ b/httpd/httpd.py
@@ -16,13 +16,17 @@ class Httpd(object):
         self.app = web.Application()
         self._setup_routes()
         self._run_app()
+        self.api_callback = None
 
     def _run_app(self):
         loop = asyncio.get_event_loop()
         handler = self.app.make_handler()
-        f = loop.create_server(handler, '0.0.0.0', 9000)
+        f = loop.create_server(handler, 'localhost', 9000)
         srv = loop.run_until_complete(f)
         print('serving on', srv.sockets[0].getsockname())
+
+    def register_api_callback(self, callback):
+        self.api_callback = callback
 
     async def handler_index(self, request):
         data = '''
@@ -78,8 +82,17 @@ class Httpd(object):
         data = str.encode(data)
         return web.Response(body=data, content_type='text/html')
 
+    async def handle_api(self, request):
+        jsonData = await request.json()
+        if self.api_callback is not None:
+            self.api_callback(jsonData)
+
+        return web.Response()
+
     def _setup_routes(self):
         absdir = os.path.dirname(os.path.realpath(__file__))
         app_path = os.path.join(absdir, 'www', 'static')
         self.app.router.add_get('/', self.handler_index)
         self.app.router.add_static('/static', app_path, show_index=True)
+        self.app.add_routes([web.get('/api/v1/dlep-update', self.handle_api),
+                             web.post('/api/v1/dlep-update', self.handle_api)])

--- a/utils/jsonconfigwriter.py
+++ b/utils/jsonconfigwriter.py
@@ -1,21 +1,14 @@
 import json
 
-'''
-===============================================================================
-CLASS JsonConfigWriter
-===============================================================================
-Intended to create a config JSON file to start the dmprd.
-It uses a given template config.json with default values for every required
-field.
-Set...(): methods are used to modify the default values.
-method writeOutputFile(...): is used to write a new JSON config file with the
-modified values at a given path
-===============================================================================
-'''
-
 
 class JsonConfigWriter:
+    """Intended to create a config JSON file to start the dmprd.
+    It uses a given template config.json with default values for every required
+    field."""
     def __init__(self, path):
+        """
+        * path: filesystem path to the default config.json
+        """
         self.templatePath = path
         self.jsonTemplateFile = open(path)
         self.jsonTemplate = self.jsonTemplateFile.read()
@@ -62,5 +55,8 @@ class JsonConfigWriter:
         self.jsonData["core"]["networks"][nr]["proto"] = proto
 
     def write_output_file(self, path):
+        """ write the new config file to filesystem
+        * path: location of new config.json
+        """
         with open(path, 'w') as outfile:
             json.dump(self.jsonData, outfile)


### PR DESCRIPTION
DMPR is now able to handle dynamic link updates. The dynamic updates are received by rest-api.
The information can be provided for example by any Radio-to-Router communication protocols (e.g. DLEP).

The new feature is tested in mininet simulation environment as well as on real hardware